### PR TITLE
Set `sp-runtime` `optional` to `false`

### DIFF
--- a/pallets/identity/Cargo.toml
+++ b/pallets/identity/Cargo.toml
@@ -16,13 +16,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-frame-benchmarking = {default-features = false, version = '3.0.0', optional = true }
+frame-benchmarking = { default-features = false, version = '3.0.0', optional = true }
 frame-support = { default-features = false, version = '3.0.0' }
 frame-system = { default-features = false, version = '3.0.0' }
 sp-io = { default-features = false, version = '3.0.0' }
 sp-std = { default-features = false, version = '3.0.0' }
-sp-runtime = { default-features = false, version = '3.0.0', optional = true }
-sp-core = { default-features = false,  version = '3.0.0', optional = false }
+sp-runtime = { default-features = false, version = '3.0.0' }
+sp-core = { default-features = false,  version = '3.0.0' }
 
 [dev-dependencies]
 sp-core = { version = '3.0.0' }


### PR DESCRIPTION
Fix compiling error when importing by litentry-node