### PR TITLE
add runtime benchmark tests for NFT

### DIFF
--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -2,10 +2,10 @@
 
 use sp_std::prelude::*;
 use sp_std::vec;
-
-use frame_benchmarking::{account, benchmarks};
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 use sp_runtime::traits::StaticLookup;
+use crate::Pallet as NFT;
 
 pub use crate::*;
 
@@ -157,3 +157,9 @@ benchmarks! {
 	}: _(RawOrigin::Signed(bob), (0u32.into(), 0u32.into()))
 
 }
+
+impl_benchmark_test_suite!(
+    NFT,
+    crate::mock::new_test_ext(),
+    crate::mock::Test,
+);

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -16,12 +16,12 @@ benchmarks! {
 	create_class {
 		let alice: T::AccountId = account("alice", 0, SEED);
 	}: _(RawOrigin::Signed(alice), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)
 
 	// mint simple NFT instances
 	mint {
@@ -32,27 +32,27 @@ benchmarks! {
 		let bob_lookup = T::Lookup::unlookup(bob);
 
 		crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )?;
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)?;
 	}: _(RawOrigin::Signed(alice), bob_lookup, 0u32.into(), vec![1], i)
 
-    // TODO: use a more realistic Merkle tree
-    // claim a claim class NFT
+	// TODO: use a more realistic Merkle tree
+	// claim a claim class NFT
 	claim {
 		let alice: T::AccountId = account("alice", 0, SEED);
 
 		// account id of bob 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-        let bob_bytes = [
+		let bob_bytes = [
 			0xd4, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x04, 0xa9,
 			0x9f, 0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56, 0x84, 0xe7,
 			0xa5, 0x6d, 0xa2, 0x7d,
 		];
-        let bob = T::AccountId::decode(&mut &bob_bytes[..]).expect("32 bytes can always construct an AccountId32");
+		let bob = T::AccountId::decode(&mut &bob_bytes[..]).expect("32 bytes can always construct an AccountId32");
 
 		// root is 0xa8a5ec29a3df3c5a8aa6fd2935d2414cf0ce4f748a13bb2833214c3b94a6d3b3
 		let merkle_root = [
@@ -69,56 +69,56 @@ benchmarks! {
 		]];
 
 		crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Claim(merkle_root)
-        )?;
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Claim(merkle_root)
+		)?;
 	}: _(RawOrigin::Signed(bob), 0, 0u32.into(), bob_proof)
 
-    // merge two simple NFT instances
-    merge {
-        let total = 1000;
-        let i in 0 .. 999;
+	// merge two simple NFT instances
+	merge {
+		let total = 1000;
+		let i in 0 .. 999;
 
 		let alice: T::AccountId = account("alice", 0, SEED);
 		let bob: T::AccountId = account("bob", 0, SEED);
 		let bob_lookup = T::Lookup::unlookup(bob.clone());
 
 		crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )?;
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)?;
 
-        crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )?; 
+		crate::Pallet::<T>::create_class(
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)?; 
 
-        crate::Pallet::<T>::mint(RawOrigin::Signed(alice.clone()).into(), bob_lookup.clone(), 0u32.into(), vec![1], total)?;
+		crate::Pallet::<T>::mint(RawOrigin::Signed(alice.clone()).into(), bob_lookup.clone(), 0u32.into(), vec![1], total)?;
 
-        crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Merge(0u32.into(), 1u32.into(), false)
-        )?; 
+		crate::Pallet::<T>::create_class(
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Merge(0u32.into(), 1u32.into(), false)
+		)?; 
 
-        crate::Pallet::<T>::mint(RawOrigin::Signed(alice).into(), bob_lookup, 1u32.into(), vec![1], total)?;
+		crate::Pallet::<T>::mint(RawOrigin::Signed(alice).into(), bob_lookup, 1u32.into(), vec![1], total)?;
 
-    }: _(RawOrigin::Signed(bob), 2u32.into(),  (0u32.into(), i.into()), (1u32.into(), i.into()))
+	}: _(RawOrigin::Signed(bob), 2u32.into(),  (0u32.into(), i.into()), (1u32.into(), i.into()))
 
 	// transfer a simple NFT instance
 	transfer {
@@ -128,13 +128,13 @@ benchmarks! {
 		let bob_lookup = T::Lookup::unlookup(bob.clone());
 
 		crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )?;
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)?;
 
 		crate::Pallet::<T>::mint(RawOrigin::Signed(alice).into(), bob_lookup, 0u32.into(), vec![1], 1)?;
 	}: _(RawOrigin::Signed(bob), alice_lookup, (0u32.into(), 0u32.into()))
@@ -146,20 +146,20 @@ benchmarks! {
 		let bob_lookup = T::Lookup::unlookup(bob.clone());
 
 		crate::Pallet::<T>::create_class(
-            RawOrigin::Signed(alice.clone()).into(), 
-            vec![1], 
-            Properties(ClassProperty::Transferable | ClassProperty::Burnable),
-            None,
-            None,
-            ClassType::Simple(999999999)
-        )?;		
+			RawOrigin::Signed(alice.clone()).into(), 
+			vec![1], 
+			Properties(ClassProperty::Transferable | ClassProperty::Burnable),
+			None,
+			None,
+			ClassType::Simple(999999999)
+		)?;		
 		crate::Pallet::<T>::mint(RawOrigin::Signed(alice).into(), bob_lookup, 0u32.into(), vec![1], 1)?;
 	}: _(RawOrigin::Signed(bob), (0u32.into(), 0u32.into()))
 
 }
 
 impl_benchmark_test_suite!(
-    NFT,
-    crate::mock::new_test_ext(),
-    crate::mock::Test,
+	NFT,
+	crate::mock::new_test_ext(),
+	crate::mock::Test,
 );

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -81,7 +81,7 @@ benchmarks! {
     // merge two simple NFT instances
     merge {
         let total = 1000;
-        let i in 1 .. 1000;
+        let i in 0 .. 999;
 
 		let alice: T::AccountId = account("alice", 0, SEED);
 		let bob: T::AccountId = account("bob", 0, SEED);


### PR DESCRIPTION
1. Offchain Worker and AccountLinker is not added because ocw has different test structure and AccountLinker's tests can not pass
Part of #42 