### PR TITLE
- merge burn flag with burn event

### DIFF
--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -341,7 +341,8 @@ pub mod pallet {
 
 			// TODO: adjustible rarity
 			let data = TokenData { used: false, rarity: 0 };
-			let start_token_id = orml_nft::Pallet::<T>::mint(&to, class_id, metadata.clone(), data.clone())?;
+			let start_token_id =
+				orml_nft::Pallet::<T>::mint(&to, class_id, metadata.clone(), data.clone())?;
 			for _ in 1..quantity {
 				orml_nft::Pallet::<T>::mint(&to, class_id, metadata.clone(), data.clone())?;
 			}
@@ -410,7 +411,8 @@ pub mod pallet {
 			// TODO: if metadata can change?
 			let metadata = class_info.metadata;
 
-			let next_token_id = orml_nft::Pallet::<T>::mint(&who, class_id, metadata.to_vec(), data)?;
+			let next_token_id =
+				orml_nft::Pallet::<T>::mint(&who, class_id, metadata.to_vec(), data)?;
 			Self::deposit_event(Event::ClaimedToken(who, class_id, next_token_id));
 			Ok(().into())
 		}
@@ -476,7 +478,8 @@ pub mod pallet {
 			// TODO: if metadata can change?
 			let metadata = merged_class_info.metadata;
 
-			let next_token_id = orml_nft::Pallet::<T>::mint(&who, class_id, metadata.to_vec(), data)?;
+			let next_token_id =
+				orml_nft::Pallet::<T>::mint(&who, class_id, metadata.to_vec(), data)?;
 			Self::deposit_event(Event::MergedToken(who, class_id, next_token_id));
 
 			Ok(().into())
@@ -516,7 +519,6 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			Self::do_burn(&who, token)?;
-			Self::deposit_event(Event::BurnedToken(who, token.0, token.1));
 			Ok(().into())
 		}
 	}
@@ -558,6 +560,7 @@ impl<T: Config> Pallet<T> {
 
 		orml_nft::Pallet::<T>::burn(&who, token)?;
 
+		Self::deposit_event(Event::BurnedToken(who.clone(), token.0, token.1));
 		Ok(())
 	}
 }

--- a/pallets/nft/src/tests.rs
+++ b/pallets/nft/src/tests.rs
@@ -694,12 +694,22 @@ fn test_merged_token_process() {
 		//---------------------//
 		//---burn merge NFT--------------------------//
 		assert_ok!(Nft::merge(Origin::signed(bob_account.clone()), 5, (2, 9), (3, 9),));
+
+		// merge will generate burn event
 		assert_eq!(
 			events_filter::<crate::Event::<Test>>()[11],
+			Event::Nft(crate::Event::BurnedToken(bob_account.clone(), 2, 9)),
+		);
+		assert_eq!(
+			events_filter::<crate::Event::<Test>>()[12],
+			Event::Nft(crate::Event::BurnedToken(bob_account.clone(), 3, 9)),
+		);
+		// merge event
+		assert_eq!(
+			events_filter::<crate::Event::<Test>>()[13],
 			Event::Nft(crate::Event::MergedToken(bob_account.clone(), 5, 0))
 		);
 
-		// merge will not generate burn event, more implement here
 		// check the owner of burned token is account #0
 		let random_account: AccountId32 = AccountId32::from([0u8; 32]);
 		assert_eq!(Nft::owner((2, 9)).unwrap_or(random_account.clone()), random_account);
@@ -711,7 +721,7 @@ fn test_merged_token_process() {
 			(2, 8)
 		));
 		assert_eq!(
-			events_filter::<crate::Event::<Test>>()[12],
+			events_filter::<crate::Event::<Test>>()[14],
 			Event::Nft(crate::Event::TransferredToken(
 				bob_account.clone(),
 				random_account.clone(),


### PR DESCRIPTION
This closes #78 . 
-quick fix the condition when merged with burn flag with no associated burn event generated.
-The corresponding test